### PR TITLE
CI: Also run on scheduled events, when no files have been changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
   lint:
     name: "Run linters"
     needs: [ build ]
-    if: ${{ needs.build.outputs.dirs-to-lint != '[]' }}
+    if: ${{ needs.build.outputs.dirs-to-lint != '[]' || github.event_name == 'schedule' }}
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +68,7 @@ jobs:
   test:
     name: "Run software tests"
     needs: [ build ]
-    if: ${{ needs.build.outputs.dirs-to-test != '[]' }}
+    if: ${{ needs.build.outputs.dirs-to-test != '[]' || github.event_name == 'schedule' }}
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@
 
 » [Documentation]
 | [Changelog]
-| [Community Forum]
 | [PyPI]
 | [Issues]
 | [Source code]
 | [License]
 | [CrateDB]
+| [Community Forum]
 
 The `langchain-cratedb` package implements core LangChain abstractions
 using [CrateDB] or [CrateDB Cloud].


### PR DESCRIPTION
## About
Extend the condition to only run linters and software tests when the outcome from GitHub Action Ana06/get-changed-files is non-empty, because this prevents running the workflows on a schedule.

## References
- https://github.com/Ana06/get-changed-files/issues/47
