### PR TITLE
Update to `crate-2.0.0`, which uses `orjson` for JSON marshalling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 
 ## Unreleased
+- Updated to `crate-2.0.0`, which uses `orjson` for JSON marshalling
 
 ## v0.1.0 - 2025-01-03
 - Added implementation and software tests for `CrateDBCache`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ python = ">=3.9,<4.0"
 langchain-community = "<0.4"
 langchain-core = "<0.4"
 langchain-postgres = "==0.0.12"
-sqlalchemy-cratedb = ">=0.40.1"
+sqlalchemy-cratedb = ">=0.41.0.dev2"
 
 [tool.ruff.lint]
 


### PR DESCRIPTION
## About
Validate and bring in an improvement to crate-python.

- https://github.com/crate/crate-python/pull/691

## References
- https://github.com/crate/crash/pull/459
- https://github.com/crate/cratedb-toolkit/pull/349
- https://github.com/crate/sqlalchemy-cratedb/pull/195
- https://github.com/crate/cratedb-examples/pull/811
