### PR TITLE
CI: Switch from `chatgpt-4o-latest` to `gpt-4o-mini`

### DIFF
--- a/docs/cache.ipynb
+++ b/docs/cache.ipynb
@@ -197,7 +197,7 @@
     ")\n",
     "\n",
     "# Invoke LLM conversation.\n",
-    "llm = ChatOpenAI(model_name=\"chatgpt-4o-latest\")\n",
+    "llm = ChatOpenAI(model_name=\"gpt-4o-mini\")\n",
     "answer = llm.invoke(\"What is the answer to everything?\")\n",
     "print(answer.content)\n",
     "\n",

--- a/examples/basic/cache.py
+++ b/examples/basic/cache.py
@@ -42,8 +42,7 @@ def standard_cache() -> None:
     # Invoke LLM conversation.
     llm = ChatOpenAI(
         # model_name="gpt-3.5-turbo",
-        # model_name="gpt-4o-mini",
-        model_name="chatgpt-4o-latest",  # type: ignore[call-arg]
+        model_name="gpt-4o-mini",  # type: ignore[call-arg]
         temperature=0.7,
     )
     print()
@@ -66,8 +65,7 @@ def semantic_cache() -> None:
     # model_name_embedding = "text-embedding-3-large"
 
     # model_name_chat = "gpt-3.5-turbo"
-    # model_name_chat = "gpt-4o-mini"
-    model_name_chat = "chatgpt-4o-latest"
+    model_name_chat = "gpt-4o-mini"
 
     # Configure embeddings.
     embeddings = OpenAIEmbeddings(model=model_name_embedding)


### PR DESCRIPTION
## Problem
CI started failing the other day.
```text
The model `chatgpt-4o-latest` does not exist or you do not have access to it.
```

## References
- GH-94